### PR TITLE
Update error_logger handler for new cowboy_handler exits

### DIFF
--- a/src/ct_helper_error_h.erl
+++ b/src/ct_helper_error_h.erl
@@ -87,8 +87,8 @@ handle_event(Event = {error, GL, {emulator, _, Msg}}, State)
 			end
 	end;
 handle_event(Event = {error, GL,
-		{_, "Ranch listener" ++ _, [_, _, Pid, {[_, _,
-			{stacktrace, [{M, F, A, _}|_]}|_], _}]}},
+		{_, "Ranch listener" ++ _, [_, _, Pid, {{cowboy_handler, [_, _, _,
+			{stacktrace, [{M, F, A, _}|_]}|_]}, _}]}},
 		State) when node(GL) =:= node() ->
 	A2 = if is_list(A) -> length(A); true -> A end,
 	Crash = {Pid, M, F, A2},


### PR DESCRIPTION
Required for https://github.com/ninenines/cowboy/pull/818. Nice to be able to remove so this code :). 